### PR TITLE
Replace set-output command by a new way to set environment variables.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,4 +44,4 @@ runs:
 
         $resourceToken = $resource.Token
         write-host "::debug::Setting 'token' variable to $resourceToken"
-        write-host "::set-output name=token::$resourceToken"
+        echo "token=$resourceToken" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Replace set-output command by a new way to set environment variables to avoid warning messages in Github Actions:

`Warning: The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`

Link Ref: Replace set-output command by a new way to set environment variables.